### PR TITLE
feat: Add short direction support to the `cexit` alias

### DIFF
--- a/Aardwolf_Rich_Exits.lua
+++ b/Aardwolf_Rich_Exits.lua
@@ -35,12 +35,12 @@ exits_after_fight = tonumber(GetVariable(exits_after_fight_var_name)) or 0
 show_window = tonumber(GetVariable(show_window_var_name)) or 1
 debug_mode = tonumber(GetVariable(debug_mode_var_name)) or 0
 
-cexit_north = GetVariable(cexit_north_var_name) or "open north;north"
-cexit_east = GetVariable(cexit_east_var_name) or "open east;east"
-cexit_south = GetVariable(cexit_south_var_name) or "open south;south"
-cexit_west = GetVariable(cexit_west_var_name) or "open west;west"
-cexit_up = GetVariable(cexit_up_var_name) or "open up;up"
-cexit_down = GetVariable(cexit_down_var_name) or "open down;down"
+cexit_north = GetVariable(cexit_north_var_name) or "open n;n"
+cexit_east = GetVariable(cexit_east_var_name) or "open e;e"
+cexit_south = GetVariable(cexit_south_var_name) or "open s;s"
+cexit_west = GetVariable(cexit_west_var_name) or "open w;w"
+cexit_up = GetVariable(cexit_up_var_name) or "open u;u"
+cexit_down = GetVariable(cexit_down_var_name) or "open d;d"
 
 local character_state = -1
 
@@ -355,8 +355,25 @@ end
 --
 
 function alias_cexit(name, line, wildcards)
-    local index = tonumber(wildcards.index)
-    local cexit = cexits[index]
+    local index = wildcards.index
+    local cexit = nil
+    if index == "n" then
+        cexit = exits.north
+    elseif index == "e" then
+        cexit = exits.east
+    elseif index == "s" then
+        cexit = exits.south
+    elseif index == "w" then
+        cexit = exits.west
+    elseif index == "u" then
+        cexit = exits.up
+    elseif index == "d" then
+        cexit = exits.down
+    else
+        index = tonumber(wildcards.index)
+        cexit = cexits[index]
+    end
+
     if cexit == nil then
         Message("Custom exit not found with index " .. index)
         return

--- a/Aardwolf_Rich_Exits.lua
+++ b/Aardwolf_Rich_Exits.lua
@@ -35,12 +35,12 @@ exits_after_fight = tonumber(GetVariable(exits_after_fight_var_name)) or 0
 show_window = tonumber(GetVariable(show_window_var_name)) or 1
 debug_mode = tonumber(GetVariable(debug_mode_var_name)) or 0
 
-cexit_north = GetVariable(cexit_north_var_name) or "open n;n"
-cexit_east = GetVariable(cexit_east_var_name) or "open e;e"
-cexit_south = GetVariable(cexit_south_var_name) or "open s;s"
-cexit_west = GetVariable(cexit_west_var_name) or "open w;w"
-cexit_up = GetVariable(cexit_up_var_name) or "open u;u"
-cexit_down = GetVariable(cexit_down_var_name) or "open d;d"
+cexit_north = GetVariable(cexit_north_var_name) or "open north;north"
+cexit_east = GetVariable(cexit_east_var_name) or "open east;east"
+cexit_south = GetVariable(cexit_south_var_name) or "open south;south"
+cexit_west = GetVariable(cexit_west_var_name) or "open west;west"
+cexit_up = GetVariable(cexit_up_var_name) or "open up;up"
+cexit_down = GetVariable(cexit_down_var_name) or "open down;down"
 
 local character_state = -1
 

--- a/Aardwolf_Rich_Exits.xml
+++ b/Aardwolf_Rich_Exits.xml
@@ -35,7 +35,7 @@ dofile(GetPluginInfo(GetPluginID(), 20) .. "Aardwolf_Rich_Exits.lua")
 
     <aliases>
         <alias
-            match="^cexit (?<index>\d+)$"
+            match="^cexit (?<index>\d+||[neswud])$"
             script="alias_cexit"
             enabled="y"
             regexp="y"


### PR DESCRIPTION
This PR adds short direction (`n`/`e`/`s`/`w`/`u`/`d`) support to the `cexit` alias allowing it to be used in hotkeys (numpad) to automatically handle any cardinal direction cexits (doors) if configured. If no cexit is configured for that direction, it will just attempt to move as normal.

This PR also updates default cexit variables values to match the values that the aard mapper appears to use by default (the short form).